### PR TITLE
Fixed interrupt glitch in ATMlib.play() (#16)

### DIFF
--- a/src/ATMlib.cpp
+++ b/src/ATMlib.cpp
@@ -109,6 +109,7 @@ static inline const byte *getTrackPointer(byte track) {
 
 
 void ATMsynth::play(const byte *song) {
+  TIMSK4 = 0b00000000;// ensure interrupt is disabled
   cia_count = 1;
   // cleanUp stuff first
   memset(channel, 0, sizeof(channel));
@@ -131,8 +132,6 @@ void ATMsynth::play(const byte *song) {
   TCCR4C = 0b01000101;
   OCR4D  = 0x80;
 #endif  
-  TIMSK4 = 0b00000100;
-
 
   // Load a melody stream and start grinding samples
   // Read track count
@@ -145,6 +144,7 @@ void ATMsynth::play(const byte *song) {
   for (unsigned n = 0; n < 4; n++) {
     channel[n].ptr = getTrackPointer(pgm_read_byte(song++));
   }
+  TIMSK4 = 0b00000100;// enable interrupt as last
 }
 
 // Stop playing, unload melody


### PR DESCRIPTION
A Timer/counter 4 overflow may happen right after the timer/counter 4 interrupt is enabled (from Arduino init() or previous song playing). When this happens the channels have not been properly set yet causing random noise/sounds being played. 
This has been fixed by disabling the interrupt at the beginning of the function and enabling at the end so no sound interrupt can occure
while the channels are being updated.